### PR TITLE
소환사명을 통한 Riot 계정 정보 단일 조회

### DIFF
--- a/src/main/kotlin/com/server/glol/domain/controller/SummonerController.kt
+++ b/src/main/kotlin/com/server/glol/domain/controller/SummonerController.kt
@@ -1,0 +1,19 @@
+package com.server.glol.domain.controller
+
+import com.server.glol.domain.dto.SummonerResponseDto
+import com.server.glol.domain.service.SummonerService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/summoner")
+class SummonerController(private val summonerService: SummonerService) {
+
+    @GetMapping("/account/{name}")
+    fun getOneSummonerAccount(@PathVariable name: String): SummonerResponseDto? {
+        return summonerService.getSummonerAccount(name)
+    }
+
+}

--- a/src/main/kotlin/com/server/glol/domain/dto/SummonerResponseDto.kt
+++ b/src/main/kotlin/com/server/glol/domain/dto/SummonerResponseDto.kt
@@ -1,0 +1,11 @@
+package com.server.glol.domain.dto
+
+class SummonerResponseDto constructor (
+    val name: String,
+    val accountId: String,
+    val summonerLevel: Int,
+    val profileIconId: Int
+) {
+
+    constructor() : this("", "", 0, 0)
+}

--- a/src/main/kotlin/com/server/glol/domain/service/SummonerService.kt
+++ b/src/main/kotlin/com/server/glol/domain/service/SummonerService.kt
@@ -1,0 +1,7 @@
+package com.server.glol.domain.service
+
+import com.server.glol.domain.dto.SummonerResponseDto
+
+interface SummonerService {
+    fun getSummonerAccount(name: String): SummonerResponseDto?
+}

--- a/src/main/kotlin/com/server/glol/domain/service/impl/SummonerServiceImpl.kt
+++ b/src/main/kotlin/com/server/glol/domain/service/impl/SummonerServiceImpl.kt
@@ -1,0 +1,28 @@
+package com.server.glol.domain.service.impl
+
+import com.server.glol.domain.dto.SummonerResponseDto
+import com.server.glol.domain.service.SummonerService
+import com.server.glol.global.config.properties.RiotProperties
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+
+@Service
+class SummonerServiceImpl
+constructor(
+    private val riotProperties: RiotProperties
+): SummonerService {
+
+    @Cacheable(key = "#name", cacheNames = ["summonerStorage"])
+    override fun getSummonerAccount(name: String): SummonerResponseDto? {
+        return WebClient.create()
+            .get()
+            .uri(riotProperties.summonerAPIUrl + name)
+            .acceptCharset(charset("UTF-8"))
+            .header("X-Riot-Token", riotProperties.secretKey)
+            .header("Origin", riotProperties.origin)
+            .retrieve()
+            .bodyToMono(SummonerResponseDto().javaClass)
+            .block()
+    }
+}

--- a/src/main/kotlin/com/server/glol/global/config/properties/RiotProperties.kt
+++ b/src/main/kotlin/com/server/glol/global/config/properties/RiotProperties.kt
@@ -1,0 +1,17 @@
+package com.server.glol.global.config.properties
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class RiotProperties(
+    @Value("\${riot.secretKey}")
+    val secretKey: String,
+
+    @Value("\${riot.summoner.name.uri}")
+    val summonerAPIUrl: String,
+
+    @Value("\${riot.origin}")
+    val origin: String
+) {
+}


### PR DESCRIPTION
# 작업 사항

## Comments of Commit

ADD
- get Summoner Account | WebClient를 이용하여 Riot api로 소환사명을 통해 Riot 계정 정보를 단일 조회