### PR TITLE
전적 관련 도메인 추가 + 전적 조회 시 필요한 Riot API url

### DIFF
--- a/src/main/kotlin/com/server/glol/domain/match/entities/Champion.kt
+++ b/src/main/kotlin/com/server/glol/domain/match/entities/Champion.kt
@@ -1,0 +1,34 @@
+package com.server.glol.domain.match.entities
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.ObjectIdGenerators
+import javax.persistence.*
+
+@Entity
+@Table(name = "champion")
+class Champion(
+
+    @Column(name = "champion_name")
+    val championName: String,
+
+    @Column(name = "champion_id")
+    val championId: Int,
+
+    @Column(name = "champion_level")
+    val championLevel: Int,
+
+    @JsonIgnore
+    @OneToOne(
+        fetch = FetchType.LAZY,
+        cascade = [CascadeType.REMOVE],
+    )
+    @JoinColumn(name = "match_idx", nullable = true)
+    val match: Match? = null,
+) {
+
+    @Column(name = "champion_idx")
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val championIdx: Long = 0
+
+}

--- a/src/main/kotlin/com/server/glol/domain/match/entities/Item.kt
+++ b/src/main/kotlin/com/server/glol/domain/match/entities/Item.kt
@@ -1,0 +1,47 @@
+package com.server.glol.domain.match.entities
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.ObjectIdGenerators
+import javax.persistence.*
+
+@Entity
+@Table(name = "item")
+class Item(
+
+        @Column(name = "item0")
+        val item0: Int,
+
+        @Column(name = "item1")
+        val item1: Int,
+
+        @Column(name = "item2")
+        val item2: Int,
+
+        @Column(name = "item3")
+        val item3: Int,
+
+        @Column(name = "item4")
+        val item4: Int,
+
+        @Column(name = "item5")
+        val item5: Int,
+
+        @Column(name = "item6")
+        val item6: Int,
+
+        @JsonIgnore
+        @OneToOne(
+            fetch = FetchType.LAZY,
+            orphanRemoval = true,
+            cascade = [CascadeType.REMOVE],
+        )
+        @JoinColumn(name = "match_idx", nullable = true)
+        val match: Match? = null,
+) {
+    @Column(name = "item_idx")
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val idx: Long = 0
+
+    constructor(): this(0,0,0,0,0,0,0, null)
+}

--- a/src/main/kotlin/com/server/glol/domain/match/entities/Match.kt
+++ b/src/main/kotlin/com/server/glol/domain/match/entities/Match.kt
@@ -1,0 +1,71 @@
+package com.server.glol.domain.match.entities
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo
+import com.fasterxml.jackson.annotation.ObjectIdGenerators
+import com.server.glol.domain.summoner.entites.Summoner
+import java.time.LocalDate
+import java.time.LocalDateTime
+import javax.persistence.*
+
+@Entity
+@Table(name = "match")
+class Match(
+
+    @Column(name = "match_id")
+    val matchId: String?,
+
+    @Column(name = "kills")
+    val kills: Int?,
+
+    @Column(name = "assists")
+    val assists: Int?,
+
+    @Column(name = "deaths")
+    val deaths: Int?,
+
+    @Column(name = "team_position")
+    val teamPosition: String?,
+
+    @Column(name = "team_id")
+    val teamId: Int?,
+
+    @Column(name = "win")
+    val win: Boolean?,
+
+    @Column(name = "wards_placed")
+    val wardsPlaced: Int?,
+
+    @Column(name = "wards_killed")
+    val wardsKilled: Int?,
+
+    @Column(name = "control_ward_placed")
+    val controlWardsPlaced: Int?,
+
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime?,
+
+    @Column(name = "renewedAt")
+    val renewedAt: LocalDate?,
+
+    @ManyToOne(
+        fetch = FetchType.LAZY,
+        cascade = [CascadeType.REMOVE],
+    )
+    @JoinColumn(name = "summoner_idx", nullable = true)
+    val summoner: Summoner,
+
+    @OneToOne(
+        mappedBy = "match"
+        )
+    val item: Item? = null,
+
+    @OneToOne(
+        mappedBy = "match",
+    )
+    val champion: Champion? = null
+) {
+
+    @Column(name = "match_idx")
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val idx: Long = 0
+}

--- a/src/main/kotlin/com/server/glol/domain/summoner/repository/SummonerCustomRepository.kt
+++ b/src/main/kotlin/com/server/glol/domain/summoner/repository/SummonerCustomRepository.kt
@@ -1,7 +1,9 @@
 package com.server.glol.domain.summoner.repository
 
+import com.server.glol.domain.summoner.entites.Summoner
 import com.server.glol.domain.summoner.repository.projection.SummonerVo
 
 interface SummonerCustomRepository {
     fun findSummonerByName(name: String) : SummonerVo?
+    fun findPuuidByName(name: String) : Summoner?
 }

--- a/src/main/kotlin/com/server/glol/domain/summoner/repository/SummonerCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/server/glol/domain/summoner/repository/SummonerCustomRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.server.glol.domain.summoner.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.server.glol.domain.summoner.entites.QSummoner.summoner
+import com.server.glol.domain.summoner.entites.Summoner
 import com.server.glol.domain.summoner.repository.projection.QSummonerVo
 import com.server.glol.domain.summoner.repository.projection.SummonerVo
 import org.springframework.stereotype.Repository
@@ -10,17 +11,24 @@ import org.springframework.stereotype.Repository
 class SummonerCustomRepositoryImpl(private val query: JPAQueryFactory) : SummonerCustomRepository {
     override fun findSummonerByName(name: String): SummonerVo? {
         return query.select(
-            QSummonerVo(
-                summoner.id,
-                summoner.accountId,
-                summoner.name,
-                summoner.puuid,
-                summoner.profileIconId,
-                summoner.visited
-            )
+                QSummonerVo(
+                        summoner.id,
+                        summoner.accountId,
+                        summoner.name,
+                        summoner.puuid,
+                        summoner.profileIconId,
+                        summoner.visited
+                )
         )
-            .from(summoner)
-            .where(summoner.name.eq(name))
-            .fetchOne()
+                .from(summoner)
+                .where(summoner.name.eq(name))
+                .fetchOne()
+    }
+
+    override fun findPuuidByName(name: String): Summoner? {
+        return query.selectFrom(
+            summoner)
+                .where(summoner.name.eq(name))
+                .fetchOne()
     }
 }

--- a/src/main/kotlin/com/server/glol/global/config/properties/RiotProperties.kt
+++ b/src/main/kotlin/com/server/glol/global/config/properties/RiotProperties.kt
@@ -5,13 +5,19 @@ import org.springframework.stereotype.Component
 
 @Component
 class RiotProperties(
-    @Value("\${riot.secretKey}")
-    val secretKey: String,
+        @Value("\${riot.secretKey}")
+        val secretKey: String,
 
-    @Value("\${riot.summoner.name.uri}")
-    val summonerAPIUrl: String,
+        @Value("\${riot.summoner.name.url}")
+        val summonerAPIUrl: String,
 
-    @Value("\${riot.origin}")
-    val origin: String
+        @Value("\${riot.match.matches.uuid.url}")
+        val matchUUIDUrl: String,
+
+        @Value("\${riot.match.matches.matchId.url}")
+        val matchesMatchIdUrl: String,
+
+        @Value("\${riot.origin}")
+        val origin: String
 ) {
 }


### PR DESCRIPTION
## 작업 사항

### Comments of Commit

#### ADD
 - __findByPuuidByName method__ : 전적 조회 시 필요한 puuid를 DB내에서 조회하기 위한 method
 - **match url** : riot api 조회에 필요한 url을 yml으로부터 가져오는 properties
 - **Match, Item, Champion Entity** : 전적 관련 조회에 필요한 엔티티 추가 